### PR TITLE
get latex string from search part of URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,9 +236,15 @@ $('.latexExample').on('click', function(e) {
   $('input#unicodeOutput').val( replace([$(this).html()]) );
 });
 
-$('input#latexInput').on('keyup', function(e) {
+$('input#latexInput').on('keyup change', function(e) {
   $('input#unicodeOutput').val( replace([$(this).val()]) );
 });
+
+
+if(location.search) {
+	var latex = location.search.slice(1);
+	$('input#latexInput').val(latex).trigger('change');
+}
     </script>
 
     <script>


### PR DESCRIPTION
I've wished unicodeit would do this for quite a while.

For example, "unicodeit.net/?\pi" should fill in the box with "\pi"