### PR TITLE
Add support for \varnothing

### DIFF
--- a/Automator/UnicodeItLatexFont2.workflow/Contents/document.wflow
+++ b/Automator/UnicodeItLatexFont2.workflow/Contents/document.wflow
@@ -259,6 +259,7 @@ replacements = [
     [ur'\\doteqdot', u'\u2251'],
     [ur'\\clubsuit', u'\u2663'],
     [ur'\\emptyset', u'\u2205'],
+    [ur'\\varnothing', u'\u2205'],
     [ur'\\sqsupset', u'\u2290'],
     [ur'\\fbox\{~~}', u'\u25AD'],
     [ur'\\curlyvee', u'\u22CE'],

--- a/GoogleAppEngine/src/converter.py
+++ b/GoogleAppEngine/src/converter.py
@@ -196,6 +196,7 @@ replacements = [
     [r'\\doteqdot', u'\u2251'],
     [r'\\clubsuit', u'\u2663'],
     [r'\\emptyset', u'\u2205'],
+    [r'\\varnothing', u'\u2205'],
     [r'\\sqsupset', u'\u2290'],
     [r'\\fbox\{~~}', u'\u25AD'],
     [r'\\curlyvee', u'\u22CE'],

--- a/GoogleAppEngine/src/unicodeit.py
+++ b/GoogleAppEngine/src/unicodeit.py
@@ -198,6 +198,7 @@ replacements = [
     [ur'\\doteqdot', u'\u2251'],
     [ur'\\clubsuit', u'\u2663'],
     [ur'\\emptyset', u'\u2205'],
+    [ur'\\varnothing', u'\u2205'],
     [ur'\\sqsupset', u'\u2290'],
     [ur'\\fbox\{~~}', u'\u25AD'],
     [ur'\\curlyvee', u'\u22CE'],

--- a/src/unicodeit.js
+++ b/src/unicodeit.js
@@ -197,6 +197,7 @@ var replacements = [
     ['\\doteqdot', '\u2251'],
     ['\\clubsuit', '\u2663'],
     ['\\emptyset', '\u2205'],
+    ['\\varnothing', '\u2205'],
     ['\\sqsupset', '\u2290'],
     ['\\fbox\{~~\}', '\u25AD'],
     ['\\curlyvee', '\u22CE'],

--- a/src/unicodeit.py
+++ b/src/unicodeit.py
@@ -200,6 +200,7 @@ replacements = [
     (r'\\doteqdot', '\u2251'),
     (r'\\clubsuit', '\u2663'),
     (r'\\emptyset', '\u2205'),
+    (r'\\varnothing', '\u2205'),
     (r'\\sqsupset', '\u2290'),
     (r'\\fbox\{~~\}', '\u25AD'),
     (r'\\curlyvee', '\u22CE'),


### PR DESCRIPTION
This PR adds support for the `\varnothing` command (that produces the ∅ symbol). It works like `\emptyset`.

Thanks for providing this great project!