### PR TITLE
Adding support for \mathcal{O} and \mathcal{o}

### DIFF
--- a/Automator/UnicodeItLatexFont2.workflow/Contents/document.wflow
+++ b/Automator/UnicodeItLatexFont2.workflow/Contents/document.wflow
@@ -185,6 +185,8 @@ replacements = [
     [ur'\\sfrac\{1}\{4}', u'\u00BC'],
     [ur'\\mathbb\{Pi}', u'\u213F'],
     [ur'\\mathcal\{M}', u'\u2133'],
+    [ur'\\mathcal\{O}', u'\u1D4AA'],
+    [ur'\\mathcal\{o}', u'\u02134'],   
     [ur'\\nsupseteqq', u'\u2289'],
     [ur'\\mathcal\{B}', u'\u212C'],
     [ur'\\textrecipe', u'\u211E'],

--- a/GoogleAppEngine/src/converter.py
+++ b/GoogleAppEngine/src/converter.py
@@ -122,6 +122,8 @@ replacements = [
     [r'\\sfrac\{1}\{4}', u'\u00BC'],
     [r'\\mathbb\{Pi}', u'\u213F'],
     [r'\\mathcal\{M}', u'\u2133'],
+    [r'\\mathcal\{O}', u'\u1D4AA'],
+    [r'\\mathcal\{o}', u'\u02134'],
     [r'\\nsupseteqq', u'\u2289'],
     [r'\\mathcal\{B}', u'\u212C'],
     [r'\\textrecipe', u'\u211E'],

--- a/GoogleAppEngine/src/unicodeit.py
+++ b/GoogleAppEngine/src/unicodeit.py
@@ -124,6 +124,8 @@ replacements = [
     [ur'\\sfrac\{1}\{4}', u'\u00BC'],
     [ur'\\mathbb\{Pi}', u'\u213F'],
     [ur'\\mathcal\{M}', u'\u2133'],
+    [ur'\\mathcal\{o\}', u'\u02134'],
+    [ur'\\mathcal\{O\}', u'\u1D4AA'],
     [ur'\\nsupseteqq', u'\u2289'],
     [ur'\\mathcal\{B}', u'\u212C'],
     [ur'\\textrecipe', u'\u211E'],

--- a/src/unicodeit.js
+++ b/src/unicodeit.js
@@ -123,6 +123,8 @@ var replacements = [
     ['\\sfrac\{1\}\{4\}', '\u00BC'],
     ['\\mathbb\{Pi\}', '\u213F'],
     ['\\mathcal\{M\}', '\u2133'],
+    ['\\mathcal\{o\}', '\u02134'],
+    ['\\mathcal\{O\}', '\u1D4AA'],    
     ['\\nsupseteqq', '\u2289'],
     ['\\mathcal\{B\}', '\u212C'],
     ['\\textrecipe', '\u211E'],

--- a/src/unicodeit.py
+++ b/src/unicodeit.py
@@ -126,6 +126,8 @@ replacements = [
     (r'\\sfrac\{1\}\{4\}', '\u00BC'),
     (r'\\mathbb\{Pi\}', '\u213F'),
     (r'\\mathcal\{M\}', '\u2133'),
+    (r'\\mathcal\{o\}', '\u02134'),
+    (r'\\mathcal\{O\}', '\u1D4AA'),
     (r'\\nsupseteqq', '\u2289'),
     (r'\\mathcal\{B\}', '\u212C'),
     (r'\\textrecipe', '\u211E'),


### PR DESCRIPTION
I'm attempting to add support for \mathcal{O} and \mathcal{o}, which should respectively give '𝒪' (`1D4AA`) and 'ℴ' (`02134`).

🍻 MLB