### PR TITLE
Handle commands like "\not\subset"

### DIFF
--- a/ts_src/replace.ts
+++ b/ts_src/replace.ts
@@ -4,6 +4,9 @@ import { combiningmarks, replacements, subsuperscripts } from './data';
 
 
 export function replace(f: string): string {
+    // Catch cases like \not\subset and \not\in and convert them to
+    // use the combining character slash as in \slash{\subset}
+    f = f.replace(/\\not(\\[A-z]+)/g, '\\slash{$1}');
     // escape combining marks with a space after the backslash
     for (const ic in combiningmarks) {
         const c = combiningmarks[ic];

--- a/unicodeit/replace.py
+++ b/unicodeit/replace.py
@@ -5,6 +5,9 @@ from .data import REPLACEMENTS, COMBININGMARKS, SUBSUPERSCRIPTS
 
 
 def replace(f: str):
+    # Catch cases like \not\subset and \not\in and convert them to
+    # use the combining character slash as in \slash{\subset}
+    f = re.sub(r'\\not(\\[A-z]+)', r'\\slash{\1}', f)
     # escape combining marks with a space after the backslash
     for c in COMBININGMARKS:
         f = f.replace(c[0] + '{', '\\ ' + c[0][1:] + '{')


### PR DESCRIPTION
LaTeX syntax like `\not\subset` will be rendered as `\u0338\u2282`, where `\not` gets directly replaced as the combining character `\u0338` (combining long solidus overlay). However, to achieve the correct result, this combining character should come after the other character. `\u0338` is listed in the combining characters list as `\\slash`, so the correct result can be achieved by either `\slash{\subset}` or `\subset\not`. 

This change catches commands like `\not\subset` or `\not\in` and replaces them with `\slash{\subset}` and `\slash{\in}` so that the correct result is rendered.