### PR TITLE
Mark the Python module with py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,12 @@ setup(
     ],
     extras_require={
         'dev': [
+            'mypy',
             'pytest',
             'pylint',
             'pycodestyle',
         ],
     },
+
+    package_data=dict(unicodeit=['py.typed'])
 )

--- a/unicodeit/replace.py
+++ b/unicodeit/replace.py
@@ -4,7 +4,7 @@ import re
 from .data import REPLACEMENTS, COMBININGMARKS, SUBSUPERSCRIPTS
 
 
-def replace(f: str):
+def replace(f: str) -> str:
     # Catch cases like \not\subset and \not\in and convert them to
     # use the combining character slash as in \slash{\subset}
     f = re.sub(r'\\not(\\[A-z]+)', r'\\slash{\1}', f)


### PR DESCRIPTION
This allows `mypy` to recognize `unicodeit` as a typed dependency as per [PEP 561](https://peps.python.org/pep-0561/).